### PR TITLE
[Feature] 매치 종류(matchtype) 메타데이터 API 통신 후 Realm에 저장

### DIFF
--- a/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
+++ b/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		044532ED28E273C400C0B08F /* DefaultRealmStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044532EC28E273C400C0B08F /* DefaultRealmStorage.swift */; };
 		044E9F3428E6ED9A003461FB /* Observable+Extesion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044E9F3328E6ED9A003461FB /* Observable+Extesion.swift */; };
 		044E9F3628E6EDD7003461FB /* RealmResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044E9F3528E6EDD7003461FB /* RealmResponseType.swift */; };
+		045046042986A180005CD24F /* MatchtypeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045046032986A180005CD24F /* MatchtypeDTO.swift */; };
 		045A2F1828AB834600A0E79B /* DefaultNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1728AB834600A0E79B /* DefaultNetworkService.swift */; };
 		045A2F1A28AB836A00A0E79B /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1928AB836A00A0E79B /* NetworkService.swift */; };
 		045A2F1C28AB841B00A0E79B /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1B28AB841B00A0E79B /* EndPoint.swift */; };
@@ -42,6 +43,7 @@
 		04DA759A28F70B55005325E9 /* FetchMetaInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DA759928F70B55005325E9 /* FetchMetaInfoUseCase.swift */; };
 		04DA759C28F70B62005325E9 /* DefaultFetchMetaInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DA759B28F70B62005325E9 /* DefaultFetchMetaInfoUseCase.swift */; };
 		04DC8A37287D89A1006B7AA9 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DC8A36287D89A1006B7AA9 /* IntroViewModel.swift */; };
+		04E6F7D72986BBD400EAC695 /* RMMatchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045046052986A1AD005CD24F /* RMMatchType.swift */; };
 		04F4A31828D2BAFA0000FC61 /* IntroCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A31728D2BAFA0000FC61 /* IntroCoordinator.swift */; };
 		04F4A31C28D2BB230000FC61 /* DefaultIntroCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A31B28D2BB230000FC61 /* DefaultIntroCoordinator.swift */; };
 		04F4A32028D2BD7A0000FC61 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A31F28D2BD7A0000FC61 /* Coordinator.swift */; };
@@ -60,6 +62,8 @@
 		044532EC28E273C400C0B08F /* DefaultRealmStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRealmStorage.swift; sourceTree = "<group>"; };
 		044E9F3328E6ED9A003461FB /* Observable+Extesion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Extesion.swift"; sourceTree = "<group>"; };
 		044E9F3528E6EDD7003461FB /* RealmResponseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmResponseType.swift; sourceTree = "<group>"; };
+		045046032986A180005CD24F /* MatchtypeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchtypeDTO.swift; sourceTree = "<group>"; };
+		045046052986A1AD005CD24F /* RMMatchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMMatchType.swift; sourceTree = "<group>"; };
 		045A2F1728AB834600A0E79B /* DefaultNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkService.swift; sourceTree = "<group>"; };
 		045A2F1928AB836A00A0E79B /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		045A2F1B28AB841B00A0E79B /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
@@ -210,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				0413456728E2C9F40077D123 /* Protocol */,
+				045046052986A1AD005CD24F /* RMMatchType.swift */,
 				0413455A28E2A9D70077D123 /* RMSpid.swift */,
 			);
 			path = DataMapping;
@@ -243,6 +248,7 @@
 				048667FA2841FF51004E7AAE /* Products */,
 				201121FCB75B15369A850451 /* Pods */,
 				246AC114B457C0AC6AFFCD53 /* Frameworks */,
+				04E6F7D62986B9E600EAC695 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -390,6 +396,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		04E6F7D62986B9E600EAC695 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				045046072986A839005CD24F /* FetchMatchtypeUseCase.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		04F4A31928D2BAFE0000FC61 /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -437,6 +451,7 @@
 		04FEEAB528C8EE6600BF005E /* DataMapping */ = {
 			isa = PBXGroup;
 			children = (
+				045046032986A180005CD24F /* MatchtypeDTO.swift */,
 				04FEEAB328C8EE6100BF005E /* SpidDTO.swift */,
 			);
 			path = DataMapping;
@@ -611,10 +626,12 @@
 				04F4A32028D2BD7A0000FC61 /* Coordinator.swift in Sources */,
 				045A2F1A28AB836A00A0E79B /* NetworkService.swift in Sources */,
 				04DC8A37287D89A1006B7AA9 /* IntroViewModel.swift in Sources */,
+				045046042986A180005CD24F /* MatchtypeDTO.swift in Sources */,
 				04D486EF28ABC90700EC2D7B /* NetworkSessionManager.swift in Sources */,
 				04D486F128ABD98000EC2D7B /* DataTransferService.swift in Sources */,
 				0413456628E2C9CA0077D123 /* RealmRepresentable.swift in Sources */,
 				04DA759A28F70B55005325E9 /* FetchMetaInfoUseCase.swift in Sources */,
+				04E6F7D72986BBD400EAC695 /* RMMatchType.swift in Sources */,
 				04F4A31828D2BAFA0000FC61 /* IntroCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -757,7 +774,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BAT7Y9H9TP;
+				DEVELOPMENT_TEAM = MH2ZJS3XW4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FIFAGG/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -769,7 +786,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "kr.ac.kpu.-.FIFAGG";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.kpu.FIFAGG;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -785,7 +802,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BAT7Y9H9TP;
+				DEVELOPMENT_TEAM = MH2ZJS3XW4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FIFAGG/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -797,7 +814,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "kr.ac.kpu.-.FIFAGG";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.ac.kpu.FIFAGG;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
+++ b/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
@@ -13,4 +13,10 @@ struct APIEndpoints {
                         method: .get,
                         headerParameters: ["If-None-Match": etag])
     }
+    
+    static func getMatchTypeEtag(etag: String) -> Endpoint<[MatchtypeDTO]> {
+        return Endpoint(path: "matchtype.json",
+                        method: .get,
+                        headerParameters: ["If-None-Match": etag])
+    }
 }

--- a/FIFAGG/FIFAGG/Data/Network/DataMapping/MatchtypeDTO.swift
+++ b/FIFAGG/FIFAGG/Data/Network/DataMapping/MatchtypeDTO.swift
@@ -1,0 +1,28 @@
+//
+//  MatchtypeDTO.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/01/29.
+//
+
+import Foundation
+
+struct MatchtypeDTO: Decodable {
+    let matchtype: Int
+    let desc: String
+    var objectID: String {
+        get {
+            return String(matchtype)
+        }
+    }
+}
+
+extension MatchtypeDTO: RealmRepresentable {
+    func asRealm() -> RMMatchType {
+        return RMMatchType.build { object in
+            object.matchtype = self.matchtype
+            object.desc = self.desc
+            object.objectID = objectID
+        }
+    }
+}

--- a/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMMatchType.swift
+++ b/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMMatchType.swift
@@ -1,0 +1,22 @@
+//
+//  RMMatchType.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/01/29.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMMatchType: Object {
+    @Persisted(primaryKey: true) var objectID: String = ""
+    @Persisted var matchtype: Int = 0
+    @Persisted var desc: String = ""
+}
+
+extension RMMatchType: RealmResponseType {
+    
+    func asResponse() -> MatchtypeDTO {
+        return MatchtypeDTO(matchtype: matchtype, desc: desc)
+    }
+}

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -75,7 +75,7 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
             self.dataTransferService.requestWithEtag(with: endpoint)
                 .subscribe(onSuccess: { (response, isServerDataUpdated, etag) in
                     
-                    UserDefaults.standard.set(etag, forKey: UserDefaultsKey.spidEtag) // 서버로 부터 받은 etag 저장
+                    UserDefaults.standard.set(etag, forKey: UserDefaultsKey.matchTypeEtag) // 서버로 부터 받은 etag 저장
                     
                     if isServerDataUpdated { // HTTP StatusCode가 200대면 isServerDataUpdated값은 true, 즉 Realm의 선수정보 업데이트
                         response?.forEach { [weak self] matchtypeDTO in

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -13,13 +13,16 @@ import RealmSwift
 final class DefaultMetaInfoRepository {
     private let dataTransferService: DataTransferService
     private let spidRealmStorage: DefaultRealmStorage<SpidDTO>
+    private let matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
     private let disposeBag = DisposeBag()
     
     init(dataTransferService: DataTransferService,
-         spidRealmStorage: DefaultRealmStorage<SpidDTO>
+         spidRealmStorage: DefaultRealmStorage<SpidDTO>,
+         matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
     ) {
         self.dataTransferService = dataTransferService
         self.spidRealmStorage = spidRealmStorage
+        self.matchtypeRealmStorage = matchtypeRealmStorage
     }
 }
 
@@ -42,6 +45,43 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
                             guard let self = self else { return }
                             
                             self.spidRealmStorage.save(entity: spidDTO)
+                                .subscribe(onNext: {
+                                    singleCloser(.success(()))
+                                }, onError: { error in
+                                    singleCloser(.failure(error))
+                                })
+                                .disposed(by: self.disposeBag)
+                        }
+                    } else { // HTTP StatusCode가 200대가 아니면 isServerDataUpdated값은 false, 즉 Realm의 선수정보 업데이트 하지 않음
+                        singleCloser(.success(()))
+                    }
+                }, onFailure: { networkError in
+                    singleCloser(.failure(networkError))
+                })
+                .disposed(by: self.disposeBag)
+
+            return Disposables.create()
+        }
+    }
+    
+    func fetchMatchTypeWithEtag() -> Single<Void> {
+        let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.matchTypeEtag) ?? ""
+        let endpoint = APIEndpoints.getMatchTypeEtag(etag: savedEtag)
+        
+        return Single<Void>.create { [weak self] singleCloser in
+            
+            guard let self = self else { return Disposables.create() }
+            
+            self.dataTransferService.requestWithEtag(with: endpoint)
+                .subscribe(onSuccess: { (response, isServerDataUpdated, etag) in
+                    
+                    UserDefaults.standard.set(etag, forKey: UserDefaultsKey.spidEtag) // 서버로 부터 받은 etag 저장
+                    
+                    if isServerDataUpdated { // HTTP StatusCode가 200대면 isServerDataUpdated값은 true, 즉 Realm의 선수정보 업데이트
+                        response?.forEach { [weak self] matchtypeDTO in
+                            guard let self = self else { return }
+                            
+                            self.matchtypeRealmStorage.save(entity: matchtypeDTO)
                                 .subscribe(onNext: {
                                     singleCloser(.success(()))
                                 }, onError: { error in

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -27,11 +27,11 @@ final class DefaultMetaInfoRepository {
 }
 
 extension DefaultMetaInfoRepository: MetaInfoRepository {
-    func fetchSpidWithEtag() -> Single<Void> {
+    func fetchSpidWithEtag() -> Observable<Void> {
         let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.spidEtag) ?? ""
         let endpoint = APIEndpoints.getSpidEtag(etag: savedEtag)
         
-        return Single<Void>.create { [weak self] singleCloser in
+        return Observable<Void>.create { [weak self] observer -> Disposable in
             
             guard let self = self else { return Disposables.create() }
             
@@ -45,30 +45,30 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
                             guard let self = self else { return }
                             
                             self.spidRealmStorage.save(entity: spidDTO)
-                                .subscribe(onNext: {
-                                    singleCloser(.success(()))
-                                }, onError: { error in
-                                    singleCloser(.failure(error))
+                                .subscribe(onError: { error in
+                                    observer.onError(error)
+                                }, onCompleted: {
+                                    observer.onCompleted()
                                 })
                                 .disposed(by: self.disposeBag)
                         }
                     } else { // HTTP StatusCode가 200대가 아니면 isServerDataUpdated값은 false, 즉 Realm의 선수정보 업데이트 하지 않음
-                        singleCloser(.success(()))
+                        observer.onCompleted()
                     }
                 }, onFailure: { networkError in
-                    singleCloser(.failure(networkError))
+                    observer.onError(networkError)
                 })
                 .disposed(by: self.disposeBag)
-
+            
             return Disposables.create()
         }
     }
     
-    func fetchMatchTypeWithEtag() -> Single<Void> {
+    func fetchMatchTypeWithEtag() -> Observable<Void> {
         let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.matchTypeEtag) ?? ""
         let endpoint = APIEndpoints.getMatchTypeEtag(etag: savedEtag)
         
-        return Single<Void>.create { [weak self] singleCloser in
+        return Observable<Void>.create { [weak self] observer -> Disposable in
             
             guard let self = self else { return Disposables.create() }
             
@@ -82,21 +82,21 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
                             guard let self = self else { return }
                             
                             self.matchtypeRealmStorage.save(entity: matchtypeDTO)
-                                .subscribe(onNext: {
-                                    singleCloser(.success(()))
-                                }, onError: { error in
-                                    singleCloser(.failure(error))
+                                .subscribe(onError: { error in
+                                    observer.onError(error)
+                                }, onCompleted: {
+                                    observer.onCompleted()
                                 })
                                 .disposed(by: self.disposeBag)
                         }
                     } else { // HTTP StatusCode가 200대가 아니면 isServerDataUpdated값은 false, 즉 Realm의 선수정보 업데이트 하지 않음
-                        singleCloser(.success(()))
+                        observer.onCompleted()
                     }
                 }, onFailure: { networkError in
-                    singleCloser(.failure(networkError))
+                    observer.onError(networkError)
                 })
                 .disposed(by: self.disposeBag)
-
+            
             return Disposables.create()
         }
     }

--- a/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
@@ -11,4 +11,5 @@ import RxSwift
 
 protocol MetaInfoRepository {
     func fetchSpidWithEtag() -> Single<Void>
+    func fetchMatchTypeWithEtag() -> Single<Void>
 }

--- a/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
@@ -10,6 +10,6 @@ import Foundation
 import RxSwift
 
 protocol MetaInfoRepository {
-    func fetchSpidWithEtag() -> Single<Void>
-    func fetchMatchTypeWithEtag() -> Single<Void>
+    func fetchSpidWithEtag() -> Observable<Void>
+    func fetchMatchTypeWithEtag() -> Observable<Void>
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
@@ -16,7 +16,10 @@ final class DefaultFetchMetaInfoUseCase: FetchMetaInfoUseCase {
         self.metaInfoRepository = metaInfoRepository
     }
     
-    func execute() -> Single<Void> {
-        return metaInfoRepository.fetchSpidWithEtag()
+    func execute() -> Observable<Void> {
+        return Observable<Void>.merge(
+            metaInfoRepository.fetchSpidWithEtag().asObservable(),
+            metaInfoRepository.fetchMatchTypeWithEtag().asObservable()
+        )
     }
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
@@ -18,8 +18,8 @@ final class DefaultFetchMetaInfoUseCase: FetchMetaInfoUseCase {
     
     func execute() -> Observable<Void> {
         return Observable<Void>.merge(
-            metaInfoRepository.fetchSpidWithEtag().asObservable(),
-            metaInfoRepository.fetchMatchTypeWithEtag().asObservable()
+            metaInfoRepository.fetchSpidWithEtag(),
+            metaInfoRepository.fetchMatchTypeWithEtag()
         )
     }
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/Protocol/FetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/Protocol/FetchMetaInfoUseCase.swift
@@ -10,5 +10,5 @@ import Foundation
 import RxSwift
 
 protocol FetchMetaInfoUseCase {
-    func execute() -> Single<Void>
+    func execute() -> Observable<Void>
 }

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
@@ -32,7 +32,8 @@ final class DefaultIntroCoordinator: IntroCoordinator {
                             )
                         )
                     ),
-                    spidRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
+                    spidRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
+                    matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
                 )
             )
         )

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
@@ -22,18 +22,22 @@ struct IntroViewModel: ViewModelType {
     
     func convert(from: Input, disposedBag: DisposeBag) -> Output {
         fetchMetaInfoUseCase.execute()
-            .subscribe {
+            .subscribe(onError: { error in
+                print(error.localizedDescription)
+            }, onCompleted: {
                 print("성공")
-                
-                // TODO: 테스트를 위한 선수 정보 로그 찍기
                 let realmSPID = DefaultRealmStorage<SpidDTO>(configuration: Realm.Configuration())
                 realmSPID.queryAll().subscribe {
                     print($0)
                 }
                 .disposed(by: disposedBag)
-            } onFailure: { error in
-                print(error.localizedDescription)
-            }
+                
+                let realmMatchtype = DefaultRealmStorage<MatchtypeDTO>(configuration: Realm.Configuration())
+                realmMatchtype.queryAll().subscribe {
+                    print($0)
+                }
+                .disposed(by: disposedBag)
+            })
             .disposed(by: disposeBag)
 
         return Output()

--- a/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
+++ b/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum UserDefaultsKey {
     static let spidEtag = "spidEtag"
+    static let matchTypeEtag = "matchTypeEtag"
 }


### PR DESCRIPTION
## 📌 이슈

close #13 

## 내용
- matchtype 메타데이터 API 통신 후 Realm에 저장
  - IntroViewModel에서 fetchMetaInfoUseCase를 통해 spid 뿐만 아니라 matchtype도 API 통신 후 Realm에 저장
- fetchMetaInfoUseCase의 excute 반환값을 Sigle에서 Observable로 변경 (Single로 Merge할 경우 에러{RxSwift.RxError error 5}가 나기 떄문)
  - 이유: Single()은 '배출된 항목이 단지 하나이고 이것을 조회해야 한다면 사용한다고 함. 근데 해당 로직에서 Single이 여러개 merge 오퍼레이터를 사용해서 에러가 남'

- MetaInfoRepository의 spid, matchtype 데이터 가져오는 메소드 반환 타입 Observable로 변경
  - fetchMetaInfoUseCase의 excute메소드에서 Observable을 사용하도록 변경했기에, MetaInfoRepository의 spid, matchtype 데이터 가져오는 메소드 반환 타입도 Observable로 통일해 불필요한 asObservable 코드를 없앰

- API 통신 시 etag사용 관련 설계
<img width="693" alt="image-20220902232739088" src="https://user-images.githubusercontent.com/35060252/216813234-d3c3353a-dcdb-4474-87da-ae963b8e258e.png">

## 테스트 방법
```swift
// matchtype 메타데이터 통신 성공 후, realm에 잘 저장되었나 확인
let realmMatchtype = DefaultRealmStorage<MatchtypeDTO>(configuration: Realm.Configuration())
                realmMatchtype.queryAll().subscribe {
                    print($0)
                }
                .disposed(by: disposedBag)
```

## 스크린샷
<img width="814" alt="image" src="https://user-images.githubusercontent.com/35060252/215339044-f6e2a524-84ee-450a-b791-9f5ff5c9a66e.png">