### PR TITLE
[Feature] 시즌아이디(seasonId) 메타데이터 API 통신 후 Realm에 저장

### DIFF
--- a/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
+++ b/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		045A2F1A28AB836A00A0E79B /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1928AB836A00A0E79B /* NetworkService.swift */; };
 		045A2F1C28AB841B00A0E79B /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1B28AB841B00A0E79B /* EndPoint.swift */; };
 		045A2F1E28AB848100A0E79B /* ApiDataNetworkConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A2F1D28AB848100A0E79B /* ApiDataNetworkConfig.swift */; };
+		047D8FC629879DAB0007CA24 /* SeasonIdDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047D8FC529879DAB0007CA24 /* SeasonIdDTO.swift */; };
+		047D8FC829879F480007CA24 /* RMSeasonId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047D8FC729879F480007CA24 /* RMSeasonId.swift */; };
 		048667FD2841FF51004E7AAE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048667FC2841FF51004E7AAE /* AppDelegate.swift */; };
 		048667FF2841FF51004E7AAE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048667FE2841FF51004E7AAE /* SceneDelegate.swift */; };
 		048668062841FF52004E7AAE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 048668052841FF52004E7AAE /* Assets.xcassets */; };
@@ -68,6 +70,8 @@
 		045A2F1928AB836A00A0E79B /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		045A2F1B28AB841B00A0E79B /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		045A2F1D28AB848100A0E79B /* ApiDataNetworkConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiDataNetworkConfig.swift; sourceTree = "<group>"; };
+		047D8FC529879DAB0007CA24 /* SeasonIdDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonIdDTO.swift; sourceTree = "<group>"; };
+		047D8FC729879F480007CA24 /* RMSeasonId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMSeasonId.swift; sourceTree = "<group>"; };
 		048667F92841FF51004E7AAE /* FIFAGG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FIFAGG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		048667FC2841FF51004E7AAE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		048667FE2841FF51004E7AAE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -216,6 +220,7 @@
 				0413456728E2C9F40077D123 /* Protocol */,
 				045046052986A1AD005CD24F /* RMMatchType.swift */,
 				0413455A28E2A9D70077D123 /* RMSpid.swift */,
+				047D8FC729879F480007CA24 /* RMSeasonId.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -399,7 +404,6 @@
 		04E6F7D62986B9E600EAC695 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				045046072986A839005CD24F /* FetchMatchtypeUseCase.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -453,6 +457,7 @@
 			children = (
 				045046032986A180005CD24F /* MatchtypeDTO.swift */,
 				04FEEAB328C8EE6100BF005E /* SpidDTO.swift */,
+				047D8FC529879DAB0007CA24 /* SeasonIdDTO.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -619,6 +624,7 @@
 				0413455B28E2A9D70077D123 /* RMSpid.swift in Sources */,
 				044E9F3628E6EDD7003461FB /* RealmResponseType.swift in Sources */,
 				04988F8328ADD3DD0013D0CF /* MetaInfoRepository.swift in Sources */,
+				047D8FC829879F480007CA24 /* RMSeasonId.swift in Sources */,
 				04DA759C28F70B62005325E9 /* DefaultFetchMetaInfoUseCase.swift in Sources */,
 				04D486ED28ABC88600EC2D7B /* DefaultNetworkSessionManager.swift in Sources */,
 				0413455F28E2B6170077D123 /* Realm+Extension.swift in Sources */,
@@ -626,6 +632,7 @@
 				04F4A32028D2BD7A0000FC61 /* Coordinator.swift in Sources */,
 				045A2F1A28AB836A00A0E79B /* NetworkService.swift in Sources */,
 				04DC8A37287D89A1006B7AA9 /* IntroViewModel.swift in Sources */,
+				047D8FC629879DAB0007CA24 /* SeasonIdDTO.swift in Sources */,
 				045046042986A180005CD24F /* MatchtypeDTO.swift in Sources */,
 				04D486EF28ABC90700EC2D7B /* NetworkSessionManager.swift in Sources */,
 				04D486F128ABD98000EC2D7B /* DataTransferService.swift in Sources */,

--- a/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
+++ b/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
@@ -19,4 +19,10 @@ struct APIEndpoints {
                         method: .get,
                         headerParameters: ["If-None-Match": etag])
     }
+    
+    static func getSeasonIdEtag(etag: String) -> Endpoint<[SeasonIdDTO]> {
+        return Endpoint(path: "seasonid.json",
+                        method: .get,
+                        headerParameters: ["If-None-Match": etag])
+    }
 }

--- a/FIFAGG/FIFAGG/Data/Network/DataMapping/SeasonIdDTO.swift
+++ b/FIFAGG/FIFAGG/Data/Network/DataMapping/SeasonIdDTO.swift
@@ -1,0 +1,36 @@
+//
+//  SeasonIdDTO.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/01/30.
+//
+
+import Foundation
+
+struct SeasonIdDTO: Decodable {
+    let seasonId: Int
+    let className: String
+    let seasonImageURL: String
+    var objectID: String {
+        get {
+            return String(seasonId)
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case seasonId
+        case className
+        case seasonImageURL = "seasonImg"
+    }
+}
+
+extension SeasonIdDTO: RealmRepresentable {
+    func asRealm() -> RMSeasonId {
+        return RMSeasonId.build { object in
+            object.seasonId = self.seasonId
+            object.className = self.className
+            object.seasonImageURL = self.seasonImageURL
+            object.objectID = self.objectID
+        }
+    }
+}

--- a/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMSeasonId.swift
+++ b/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMSeasonId.swift
@@ -1,0 +1,27 @@
+//
+//  RMSeasonId.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/01/30.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMSeasonId: Object {
+    @Persisted(primaryKey: true) var objectID: String = ""
+    @Persisted var seasonId: Int
+    @Persisted var className: String
+    @Persisted var seasonImageURL: String
+}
+
+extension RMSeasonId: RealmResponseType {
+    
+    func asResponse() -> SeasonIdDTO {
+        return SeasonIdDTO(
+            seasonId: self.seasonId,
+            className: self.className,
+            seasonImageURL: self.seasonImageURL
+        )
+    }
+}

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -14,15 +14,18 @@ final class DefaultMetaInfoRepository {
     private let dataTransferService: DataTransferService
     private let spidRealmStorage: DefaultRealmStorage<SpidDTO>
     private let matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
+    private let seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>
     private let disposeBag = DisposeBag()
     
     init(dataTransferService: DataTransferService,
          spidRealmStorage: DefaultRealmStorage<SpidDTO>,
-         matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
+         matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>,
+         seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>
     ) {
         self.dataTransferService = dataTransferService
         self.spidRealmStorage = spidRealmStorage
         self.matchtypeRealmStorage = matchtypeRealmStorage
+        self.seasonIdRealmStorage = seasonIdRealmStorage
     }
 }
 
@@ -82,6 +85,43 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
                             guard let self = self else { return }
                             
                             self.matchtypeRealmStorage.save(entity: matchtypeDTO)
+                                .subscribe(onError: { error in
+                                    observer.onError(error)
+                                }, onCompleted: {
+                                    observer.onCompleted()
+                                })
+                                .disposed(by: self.disposeBag)
+                        }
+                    } else { // HTTP StatusCode가 200대가 아니면 isServerDataUpdated값은 false, 즉 Realm의 선수정보 업데이트 하지 않음
+                        observer.onCompleted()
+                    }
+                }, onFailure: { networkError in
+                    observer.onError(networkError)
+                })
+                .disposed(by: self.disposeBag)
+            
+            return Disposables.create()
+        }
+    }
+    
+    func fetchSeasonIdWithEtag() -> Observable<Void> {
+        let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.seasonIdEtag) ?? ""
+        let endpoint = APIEndpoints.getSeasonIdEtag(etag: savedEtag)
+        
+        return Observable<Void>.create { [weak self] observer -> Disposable in
+            
+            guard let self = self else { return Disposables.create() }
+            
+            self.dataTransferService.requestWithEtag(with: endpoint)
+                .subscribe(onSuccess: { (response, isServerDataUpdated, etag) in
+                    
+                    UserDefaults.standard.set(etag, forKey: UserDefaultsKey.seasonIdEtag) // 서버로 부터 받은 etag 저장
+                    
+                    if isServerDataUpdated { // HTTP StatusCode가 200대면 isServerDataUpdated값은 true, 즉 Realm의 선수정보 업데이트
+                        response?.forEach { [weak self] seasonIdDTO in
+                            guard let self = self else { return }
+                            
+                            self.seasonIdRealmStorage.save(entity: seasonIdDTO)
                                 .subscribe(onError: { error in
                                     observer.onError(error)
                                 }, onCompleted: {

--- a/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
@@ -12,4 +12,5 @@ import RxSwift
 protocol MetaInfoRepository {
     func fetchSpidWithEtag() -> Observable<Void>
     func fetchMatchTypeWithEtag() -> Observable<Void>
+    func fetchSeasonIdWithEtag() -> Observable<Void>
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
@@ -19,7 +19,8 @@ final class DefaultFetchMetaInfoUseCase: FetchMetaInfoUseCase {
     func execute() -> Observable<Void> {
         return Observable<Void>.merge(
             metaInfoRepository.fetchSpidWithEtag(),
-            metaInfoRepository.fetchMatchTypeWithEtag()
+            metaInfoRepository.fetchMatchTypeWithEtag(),
+            metaInfoRepository.fetchSeasonIdWithEtag()
         )
     }
 }

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
@@ -33,7 +33,7 @@ final class DefaultIntroCoordinator: IntroCoordinator {
                         )
                     ),
                     spidRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
-                    matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
+                    matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()), seasonIdRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
                 )
             )
         )

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
@@ -37,6 +37,12 @@ struct IntroViewModel: ViewModelType {
                     print($0)
                 }
                 .disposed(by: disposedBag)
+                
+                let realmSeasonId = DefaultRealmStorage<SeasonIdDTO>(configuration: Realm.Configuration())
+                realmSeasonId.queryAll().subscribe {
+                    print($0)
+                }
+                .disposed(by: disposedBag)
             })
             .disposed(by: disposeBag)
 

--- a/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
+++ b/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
@@ -10,4 +10,5 @@ import Foundation
 enum UserDefaultsKey {
     static let spidEtag = "spidEtag"
     static let matchTypeEtag = "matchTypeEtag"
+    static let seasonIdEtag = "seasonIdEtag"
 }


### PR DESCRIPTION
## 📌 이슈

close #15 

## 내용
- 시즌아이디(seasonId) 메타데이터 API 통신 후 Realm에 저장

## 테스트 방법
```swift
// 시즌아이디(seasonId) 메타데이터 통신 성공 후, realm에 잘 저장되었나 확인
let realmSeasonId = DefaultRealmStorage<SeasonIdDTO>(configuration: Realm.Configuration())
realmSeasonId.queryAll().subscribe {
          print($0)
}
.disposed(by: disposedBag)
```

## 스크린샷
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/35060252/215418866-df5db9d5-b6e1-4133-9737-c4e8d289861c.png">