### PR TITLE
[Fix] 메타데이터들 fetch하는 Usecase의 execute메소드 반환값 Observable의 onCompleted 부분 한번만 호출되도록 수정

### DIFF
--- a/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DefaultRealmStorage.swift
+++ b/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DefaultRealmStorage.swift
@@ -53,6 +53,12 @@ final class DefaultRealmStorage<T: RealmRepresentable>: RealmStorage where T == 
         }
     }
 
+    func save(entities: [T]) -> Observable<Void> {
+        return Observable.deferred {
+            return self.realm.rx.save(entities: entities)
+        }
+    }
+    
     func delete(entity: T) -> Observable<Void> {
         return Observable.deferred {
             return self.realm.rx.delete(entity: entity)

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -81,17 +81,18 @@ private extension DefaultMetaInfoRepository {
                     UserDefaults.standard.set(etag, forKey: userDefaultsKey) // 서버로 부터 받은 etag 저장
                     
                     if isServerDataUpdated { // HTTP StatusCode가 200대면 isServerDataUpdated값은 true, 즉 Realm의 선수정보 업데이트
-                        response?.forEach { [weak self] metaInfoDTO in
-                            guard let self = self else { return }
-                            
-                            metaInfoRealmStorage.save(entity: metaInfoDTO)
-                                .subscribe(onError: { error in
-                                    observer.onError(error)
-                                }, onCompleted: {
-                                    observer.onCompleted()
-                                })
-                                .disposed(by: self.disposeBag)
+                        guard let response = response else {
+                            observer.onCompleted()
+                            return
                         }
+                        
+                        metaInfoRealmStorage.save(entities: response)
+                            .subscribe(onError: { error in
+                                observer.onError(error)
+                            },onCompleted: {
+                                observer.onCompleted()
+                            })
+                            .disposed(by: self.disposeBag)
                     } else { // HTTP StatusCode가 200대가 아니면 isServerDataUpdated값은 false, 즉 Realm의 선수정보 업데이트 하지 않음
                         observer.onCompleted()
                     }

--- a/FIFAGG/FIFAGG/Utility/Extension/Realm+Extension.swift
+++ b/FIFAGG/FIFAGG/Utility/Extension/Realm+Extension.swift
@@ -40,6 +40,23 @@ extension Reactive where Base == Realm {
         }
     }
 
+    func save<R: RealmRepresentable>(entities: [R], update: Bool = true) -> Observable<Void> where R.RealmType: Object {
+        return Observable.create { observer in
+            do {
+                try self.base.write {
+                    for entity in entities {
+                        self.base.add(entity.asRealm(), update: update ? .all : .error)
+                    }
+                }
+                observer.onNext(())
+                observer.onCompleted()
+            } catch {
+                observer.onError(error)
+            }
+            return Disposables.create()
+        }
+    }
+    
     func delete<R: RealmRepresentable>(entity: R) -> Observable<Void> where R.RealmType: Object {
         return Observable.create { observer in
             do {


### PR DESCRIPTION
## 📌 이슈

close #21 

## 내용
- 메타데이터들 fetch하는 Usecase의 execute메소드 반환값 Observable의 onCompleted 부분 한번만 호출되도록 수정
  - 원인: 기존에는 메타데이터가 array형식인데, **array 요소마다** realm에 저장하고 Observable의 이벤트들(error, completed)을 반환해 매번 onError나 onCompleted가 호출되었음
  - 해결: 수정된 코드는 메타데이터 array 전체를 한번에 저장하고 Observable의 이벤트들도 매번 반환되지 않아, 한번만 onError나 onCompleted가 호출되도록 수정

## 테스트 방법
```swift
DefaultFetchMetaInfoUseCase().execute()
            .subscribe(onError: { error in
                print(error.localizedDescription)
            }, onCompleted: {
                print("성공")
            })
            .disposed(by: disposeBag)
```