### PR TITLE
[Feature] 선수 포지션(SPPosition) 메타데이터 API 통신 후 Realm에 저장

### DIFF
--- a/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
+++ b/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		04A3988028D99924007D93B7 /* DefaultAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A3987F28D99924007D93B7 /* DefaultAppCoordinator.swift */; };
 		04A3988428D99E06007D93B7 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A3988328D99E06007D93B7 /* AppCoordinator.swift */; };
 		04C3283928EC8210006A47D7 /* RxRealm in Frameworks */ = {isa = PBXBuildFile; productRef = 04C3283828EC8210006A47D7 /* RxRealm */; };
+		04C6F50129896658003D9268 /* SPPostionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6F50029896658003D9268 /* SPPostionDTO.swift */; };
+		04C6F503298966CC003D9268 /* RMSPPostion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6F502298966CC003D9268 /* RMSPPostion.swift */; };
 		04D486ED28ABC88600EC2D7B /* DefaultNetworkSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D486EC28ABC88600EC2D7B /* DefaultNetworkSessionManager.swift */; };
 		04D486EF28ABC90700EC2D7B /* NetworkSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D486EE28ABC90700EC2D7B /* NetworkSessionManager.swift */; };
 		04D486F128ABD98000EC2D7B /* DataTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D486F028ABD98000EC2D7B /* DataTransferService.swift */; };
@@ -85,6 +87,8 @@
 		04A3987C28D998CA007D93B7 /* CoordinatorFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFinishDelegate.swift; sourceTree = "<group>"; };
 		04A3987F28D99924007D93B7 /* DefaultAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppCoordinator.swift; sourceTree = "<group>"; };
 		04A3988328D99E06007D93B7 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		04C6F50029896658003D9268 /* SPPostionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPPostionDTO.swift; sourceTree = "<group>"; };
+		04C6F502298966CC003D9268 /* RMSPPostion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMSPPostion.swift; sourceTree = "<group>"; };
 		04D486EC28ABC88600EC2D7B /* DefaultNetworkSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkSessionManager.swift; sourceTree = "<group>"; };
 		04D486EE28ABC90700EC2D7B /* NetworkSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionManager.swift; sourceTree = "<group>"; };
 		04D486F028ABD98000EC2D7B /* DataTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTransferService.swift; sourceTree = "<group>"; };
@@ -221,6 +225,7 @@
 				045046052986A1AD005CD24F /* RMMatchType.swift */,
 				0413455A28E2A9D70077D123 /* RMSpid.swift */,
 				047D8FC729879F480007CA24 /* RMSeasonId.swift */,
+				04C6F502298966CC003D9268 /* RMSPPostion.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -458,6 +463,7 @@
 				045046032986A180005CD24F /* MatchtypeDTO.swift */,
 				04FEEAB328C8EE6100BF005E /* SpidDTO.swift */,
 				047D8FC529879DAB0007CA24 /* SeasonIdDTO.swift */,
+				04C6F50029896658003D9268 /* SPPostionDTO.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -604,6 +610,7 @@
 			files = (
 				045A2F1E28AB848100A0E79B /* ApiDataNetworkConfig.swift in Sources */,
 				045A2F1C28AB841B00A0E79B /* EndPoint.swift in Sources */,
+				04C6F503298966CC003D9268 /* RMSPPostion.swift in Sources */,
 				04A3988428D99E06007D93B7 /* AppCoordinator.swift in Sources */,
 				04A3987D28D998CA007D93B7 /* CoordinatorFinishDelegate.swift in Sources */,
 				04988F8128ADD2110013D0CF /* DefaultMetaInfoRepository.swift in Sources */,
@@ -636,6 +643,7 @@
 				045046042986A180005CD24F /* MatchtypeDTO.swift in Sources */,
 				04D486EF28ABC90700EC2D7B /* NetworkSessionManager.swift in Sources */,
 				04D486F128ABD98000EC2D7B /* DataTransferService.swift in Sources */,
+				04C6F50129896658003D9268 /* SPPostionDTO.swift in Sources */,
 				0413456628E2C9CA0077D123 /* RealmRepresentable.swift in Sources */,
 				04DA759A28F70B55005325E9 /* FetchMetaInfoUseCase.swift in Sources */,
 				04E6F7D72986BBD400EAC695 /* RMMatchType.swift in Sources */,

--- a/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
+++ b/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
@@ -25,4 +25,10 @@ struct APIEndpoints {
                         method: .get,
                         headerParameters: ["If-None-Match": etag])
     }
+    
+    static func getSPPositionEtag(etag: String) -> Endpoint<[SPPostionDTO]> {
+        return Endpoint(path: "spposition.json",
+                        method: .get,
+                        headerParameters: ["If-None-Match": etag])
+    }
 }

--- a/FIFAGG/FIFAGG/Data/Network/DataMapping/SPPostionDTO.swift
+++ b/FIFAGG/FIFAGG/Data/Network/DataMapping/SPPostionDTO.swift
@@ -1,0 +1,33 @@
+//
+//  SPPostionDTO.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/02/01.
+//
+
+import Foundation
+
+struct SPPostionDTO: Decodable {
+    let spPosition: Int
+    let desc: String
+    var objectID: String {
+        get {
+            return String(spPosition)
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case spPosition = "spposition"
+        case desc
+    }
+}
+
+extension SPPostionDTO: RealmRepresentable {
+    func asRealm() -> RMSPPostion {
+        return RMSPPostion.build { object in
+            object.spPosition = self.spPosition
+            object.desc = self.desc
+            object.objectID = self.objectID
+        }
+    }
+}

--- a/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMSPPostion.swift
+++ b/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMSPPostion.swift
@@ -1,0 +1,25 @@
+//
+//  RMSPPostion.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/02/01.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMSPPostion: Object {
+    @Persisted(primaryKey: true) var objectID: String = ""
+    @Persisted var spPosition: Int
+    @Persisted var desc: String
+}
+
+extension RMSPPostion: RealmResponseType {
+    
+    func asResponse() -> SPPostionDTO {
+        return SPPostionDTO(
+            spPosition: self.spPosition,
+            desc: self.desc
+        )
+    }
+}

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -15,17 +15,20 @@ final class DefaultMetaInfoRepository {
     private let spidRealmStorage: DefaultRealmStorage<SpidDTO>
     private let matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
     private let seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>
+    private let spPositionRealmStorage: DefaultRealmStorage<SPPostionDTO>
     private let disposeBag = DisposeBag()
     
     init(dataTransferService: DataTransferService,
          spidRealmStorage: DefaultRealmStorage<SpidDTO>,
          matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>,
-         seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>
+         seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>,
+         spPositionRealmStorage: DefaultRealmStorage<SPPostionDTO>
     ) {
         self.dataTransferService = dataTransferService
         self.spidRealmStorage = spidRealmStorage
         self.matchtypeRealmStorage = matchtypeRealmStorage
         self.seasonIdRealmStorage = seasonIdRealmStorage
+        self.spPositionRealmStorage = spPositionRealmStorage
     }
 }
 
@@ -60,6 +63,17 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
             metaInfoRealmStorage: self.seasonIdRealmStorage,
             endpoint: endpoint,
             userDefaultsKey: UserDefaultsKey.seasonIdEtag
+        )
+    }
+    
+    func fetchSPPositionWithEtag() -> Observable<Void> {
+        let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.spPosition) ?? ""
+        let endpoint = APIEndpoints.getSPPositionEtag(etag: savedEtag)
+        
+        return self.fetchMetaInfo(
+            metaInfoRealmStorage: self.spPositionRealmStorage,
+            endpoint: endpoint,
+            userDefaultsKey: UserDefaultsKey.spPosition
         )
     }
 }

--- a/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
@@ -13,4 +13,5 @@ protocol MetaInfoRepository {
     func fetchSpidWithEtag() -> Observable<Void>
     func fetchMatchTypeWithEtag() -> Observable<Void>
     func fetchSeasonIdWithEtag() -> Observable<Void>
+    func fetchSPPositionWithEtag() -> Observable<Void>
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
@@ -20,7 +20,8 @@ final class DefaultFetchMetaInfoUseCase: FetchMetaInfoUseCase {
         return Observable<Void>.merge(
             metaInfoRepository.fetchSpidWithEtag(),
             metaInfoRepository.fetchMatchTypeWithEtag(),
-            metaInfoRepository.fetchSeasonIdWithEtag()
+            metaInfoRepository.fetchSeasonIdWithEtag(),
+            metaInfoRepository.fetchSPPositionWithEtag()
         )
     }
 }

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
@@ -33,7 +33,9 @@ final class DefaultIntroCoordinator: IntroCoordinator {
                         )
                     ),
                     spidRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
-                    matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()), seasonIdRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
+                    matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
+                    seasonIdRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
+                    spPositionRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
                 )
             )
         )

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
@@ -43,6 +43,12 @@ struct IntroViewModel: ViewModelType {
                     print($0)
                 }
                 .disposed(by: disposedBag)
+               
+                let realmSPPosition = DefaultRealmStorage<SPPostionDTO>(configuration: Realm.Configuration())
+                realmSPPosition.queryAll().subscribe {
+                    print($0)
+                }
+                .disposed(by: disposedBag)
             })
             .disposed(by: disposeBag)
 

--- a/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
+++ b/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
@@ -11,4 +11,5 @@ enum UserDefaultsKey {
     static let spidEtag = "spidEtag"
     static let matchTypeEtag = "matchTypeEtag"
     static let seasonIdEtag = "seasonIdEtag"
+    static let spPosition = "spPosition"
 }


### PR DESCRIPTION
## 📌 이슈

close #20  

## 내용
- 선수 포지션(spposition) 메타데이터 API 통신 후 Realm에 저장

## 테스트 방법
```swift
// 선수 포지션(spposition) 메타데이터 통신 성공 후, realm에 잘 저장되었나 확인
let realmSPPosition = DefaultRealmStorage<SPPostionDTO>(configuration: Realm.Configuration())

realmSPPosition.queryAll().subscribe {
             print($0)
}
.disposed(by: disposedBag)
```

## 스크린샷
![image](https://user-images.githubusercontent.com/35060252/215833005-7527bbc7-318b-4eba-8933-cd8c33a2de28.png)
