### PR TITLE
[Feature] 등급 식별자(division) 메타데이터 API 통신 후 Realm에 저장

### DIFF
--- a/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
+++ b/FIFAGG/FIFAGG.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		04A3987D28D998CA007D93B7 /* CoordinatorFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A3987C28D998CA007D93B7 /* CoordinatorFinishDelegate.swift */; };
 		04A3988028D99924007D93B7 /* DefaultAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A3987F28D99924007D93B7 /* DefaultAppCoordinator.swift */; };
 		04A3988428D99E06007D93B7 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A3988328D99E06007D93B7 /* AppCoordinator.swift */; };
+		04BDA3ED299281880020EB58 /* DivisionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BDA3EC299281880020EB58 /* DivisionDTO.swift */; };
+		04BDA3EF299281E60020EB58 /* RMDivision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BDA3EE299281E60020EB58 /* RMDivision.swift */; };
 		04C3283928EC8210006A47D7 /* RxRealm in Frameworks */ = {isa = PBXBuildFile; productRef = 04C3283828EC8210006A47D7 /* RxRealm */; };
 		04C6F50129896658003D9268 /* SPPostionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6F50029896658003D9268 /* SPPostionDTO.swift */; };
 		04C6F503298966CC003D9268 /* RMSPPostion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C6F502298966CC003D9268 /* RMSPPostion.swift */; };
@@ -92,6 +94,8 @@
 		04A3987C28D998CA007D93B7 /* CoordinatorFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFinishDelegate.swift; sourceTree = "<group>"; };
 		04A3987F28D99924007D93B7 /* DefaultAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppCoordinator.swift; sourceTree = "<group>"; };
 		04A3988328D99E06007D93B7 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		04BDA3EC299281880020EB58 /* DivisionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DivisionDTO.swift; sourceTree = "<group>"; };
+		04BDA3EE299281E60020EB58 /* RMDivision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMDivision.swift; sourceTree = "<group>"; };
 		04C6F50029896658003D9268 /* SPPostionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPPostionDTO.swift; sourceTree = "<group>"; };
 		04C6F502298966CC003D9268 /* RMSPPostion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMSPPostion.swift; sourceTree = "<group>"; };
 		04D486EC28ABC88600EC2D7B /* DefaultNetworkSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkSessionManager.swift; sourceTree = "<group>"; };
@@ -233,6 +237,7 @@
 				0413455A28E2A9D70077D123 /* RMSpid.swift */,
 				047D8FC729879F480007CA24 /* RMSeasonId.swift */,
 				04C6F502298966CC003D9268 /* RMSPPostion.swift */,
+				04BDA3EE299281E60020EB58 /* RMDivision.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -469,6 +474,7 @@
 				04FEEAB328C8EE6100BF005E /* SpidDTO.swift */,
 				047D8FC529879DAB0007CA24 /* SeasonIdDTO.swift */,
 				04C6F50029896658003D9268 /* SPPostionDTO.swift */,
+				04BDA3EC299281880020EB58 /* DivisionDTO.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -572,8 +578,10 @@
 				045A2F1828AB834600A0E79B /* DefaultNetworkService.swift in Sources */,
 				04213A0B2869A9E600C50CFC /* IntroViewController.swift in Sources */,
 				04D486F328ABDAC000EC2D7B /* DefaultDataTransferService.swift in Sources */,
+				04BDA3ED299281880020EB58 /* DivisionDTO.swift in Sources */,
 				0415CCF32880143E008967F9 /* ViewModelType.swift in Sources */,
 				04F4A31C28D2BB230000FC61 /* DefaultIntroCoordinator.swift in Sources */,
+				04BDA3EF299281E60020EB58 /* RMDivision.swift in Sources */,
 				048667FD2841FF51004E7AAE /* AppDelegate.swift in Sources */,
 				04988F6C28ACAA930013D0CF /* NetworkConfigurable.swift in Sources */,
 				044E9F3428E6ED9A003461FB /* Observable+Extesion.swift in Sources */,

--- a/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
+++ b/FIFAGG/FIFAGG/Data/Network/APIEndpoints.swift
@@ -31,4 +31,10 @@ struct APIEndpoints {
                         method: .get,
                         headerParameters: ["If-None-Match": etag])
     }
+    
+    static func getDivisionEtag(etag: String) -> Endpoint<[DivisionDTO]> {
+        return Endpoint(path: "division.json",
+                        method: .get,
+                        headerParameters: ["If-None-Match": etag])
+    }
 }

--- a/FIFAGG/FIFAGG/Data/Network/DataMapping/DivisionDTO.swift
+++ b/FIFAGG/FIFAGG/Data/Network/DataMapping/DivisionDTO.swift
@@ -1,0 +1,28 @@
+//
+//  DivisionDTO.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/02/07.
+//
+
+import Foundation
+
+struct DivisionDTO: Decodable {
+    let divisionId: Int
+    let divisionName: String
+    var objectID: String {
+        get {
+            return String(divisionId)
+        }
+    }
+}
+
+extension DivisionDTO: RealmRepresentable {
+    func asRealm() -> RMDivision {
+        return RMSPPostion.build { object in
+            object.divisionId = self.divisionId
+            object.divisionName = self.divisionName
+            object.objectID = self.objectID
+        }
+    }
+}

--- a/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMDivision.swift
+++ b/FIFAGG/FIFAGG/Data/PersistentStorages/Realm/DataMapping/RMDivision.swift
@@ -1,0 +1,25 @@
+//
+//  RMDivision.swift
+//  FIFAGG
+//
+//  Created by Joseph Cha on 2023/02/07.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMDivision: Object {
+    @Persisted(primaryKey: true) var objectID: String = ""
+    @Persisted var divisionId: Int
+    @Persisted var divisionName: String
+}
+
+extension RMDivision: RealmResponseType {
+    
+    func asResponse() -> DivisionDTO {
+        return DivisionDTO(
+            divisionId: self.divisionId,
+            divisionName: self.divisionName
+        )
+    }
+}

--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -16,19 +16,22 @@ final class DefaultMetaInfoRepository {
     private let matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>
     private let seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>
     private let spPositionRealmStorage: DefaultRealmStorage<SPPostionDTO>
+    private let divisionRealmStorage: DefaultRealmStorage<DivisionDTO>
     private let disposeBag = DisposeBag()
     
     init(dataTransferService: DataTransferService,
          spidRealmStorage: DefaultRealmStorage<SpidDTO>,
          matchtypeRealmStorage: DefaultRealmStorage<MatchtypeDTO>,
          seasonIdRealmStorage: DefaultRealmStorage<SeasonIdDTO>,
-         spPositionRealmStorage: DefaultRealmStorage<SPPostionDTO>
+         spPositionRealmStorage: DefaultRealmStorage<SPPostionDTO>,
+         divisionRealmStorage: DefaultRealmStorage<DivisionDTO>
     ) {
         self.dataTransferService = dataTransferService
         self.spidRealmStorage = spidRealmStorage
         self.matchtypeRealmStorage = matchtypeRealmStorage
         self.seasonIdRealmStorage = seasonIdRealmStorage
         self.spPositionRealmStorage = spPositionRealmStorage
+        self.divisionRealmStorage = divisionRealmStorage
     }
 }
 
@@ -72,6 +75,17 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
         
         return self.fetchMetaInfo(
             metaInfoRealmStorage: self.spPositionRealmStorage,
+            endpoint: endpoint,
+            userDefaultsKey: UserDefaultsKey.spPosition
+        )
+    }
+    
+    func fetchDivisionWithEtag() -> Observable<Void> {
+        let savedEtag: String = UserDefaults.standard.string(forKey: UserDefaultsKey.division) ?? ""
+        let endpoint = APIEndpoints.getDivisionEtag(etag: savedEtag)
+        
+        return self.fetchMetaInfo(
+            metaInfoRealmStorage: self.divisionRealmStorage,
             endpoint: endpoint,
             userDefaultsKey: UserDefaultsKey.spPosition
         )

--- a/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/Protocol/MetaInfoRepository.swift
@@ -14,4 +14,5 @@ protocol MetaInfoRepository {
     func fetchMatchTypeWithEtag() -> Observable<Void>
     func fetchSeasonIdWithEtag() -> Observable<Void>
     func fetchSPPositionWithEtag() -> Observable<Void>
+    func fetchDivisionWithEtag() -> Observable<Void>
 }

--- a/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
+++ b/FIFAGG/FIFAGG/Domain/Usecase/DefaultFetchMetaInfoUseCase.swift
@@ -21,7 +21,8 @@ final class DefaultFetchMetaInfoUseCase: FetchMetaInfoUseCase {
             metaInfoRepository.fetchSpidWithEtag(),
             metaInfoRepository.fetchMatchTypeWithEtag(),
             metaInfoRepository.fetchSeasonIdWithEtag(),
-            metaInfoRepository.fetchSPPositionWithEtag()
+            metaInfoRepository.fetchSPPositionWithEtag(),
+            metaInfoRepository.fetchDivisionWithEtag()
         )
     }
 }

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/Coordinator/DefaultIntroCoordinator.swift
@@ -35,7 +35,8 @@ final class DefaultIntroCoordinator: IntroCoordinator {
                     spidRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
                     matchtypeRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
                     seasonIdRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
-                    spPositionRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
+                    spPositionRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration()),
+                    divisionRealmStorage: DefaultRealmStorage(configuration: Realm.Configuration())
                 )
             )
         )

--- a/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
+++ b/FIFAGG/FIFAGG/Presentation/IntroScene/ViewModel/IntroViewModel.swift
@@ -49,6 +49,12 @@ struct IntroViewModel: ViewModelType {
                     print($0)
                 }
                 .disposed(by: disposedBag)
+                
+                let realmDivision = DefaultRealmStorage<DivisionDTO>(configuration: Realm.Configuration())
+                realmDivision.queryAll().subscribe {
+                    print($0)
+                }
+                .disposed(by: disposedBag)
             })
             .disposed(by: disposeBag)
 

--- a/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
+++ b/FIFAGG/FIFAGG/Utility/Constant/UserDefaultsKey.swift
@@ -12,4 +12,5 @@ enum UserDefaultsKey {
     static let matchTypeEtag = "matchTypeEtag"
     static let seasonIdEtag = "seasonIdEtag"
     static let spPosition = "spPosition"
+    static let division = "division"
 }


### PR DESCRIPTION
## 📌 이슈

close #29 

## 내용
- 등급 식별자(division) 메타데이터 API 통신 후 Realm에 저장

## 테스트 방법
```swift
// 선수 포지션(spposition) 메타데이터 통신 성공 후, realm에 잘 저장되었나 확인
let realmDivision = DefaultRealmStorage<DivisionDTO>(configuration: Realm.Configuration())
realmDivision.queryAll().subscribe {
            print($0)
}
.disposed(by: disposedBag)
```

## 스크린샷
![image](https://user-images.githubusercontent.com/35060252/217391662-d126d939-bf15-429b-b3ab-89540d8c3a15.png)
