### PR TITLE
[Fix] 매번 메타데이터 API response값 불러와 Realm에 저장하는 오류 해결

### DIFF
--- a/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
+++ b/FIFAGG/FIFAGG/Data/Repositories/DefaultMetaInfoRepository.swift
@@ -87,7 +87,7 @@ extension DefaultMetaInfoRepository: MetaInfoRepository {
         return self.fetchMetaInfo(
             metaInfoRealmStorage: self.divisionRealmStorage,
             endpoint: endpoint,
-            userDefaultsKey: UserDefaultsKey.spPosition
+            userDefaultsKey: UserDefaultsKey.division
         )
     }
 }

--- a/FIFAGG/FIFAGG/Infrastructure/Network/DefaultDataTransferService.swift
+++ b/FIFAGG/FIFAGG/Infrastructure/Network/DefaultDataTransferService.swift
@@ -82,7 +82,7 @@ extension DefaultDataTransferService: DataTransferService {
                         let result: Single<T> = self.decode(data: data, decoder: endpoint.responseDecoder)
                         return result.map { ($0, isServerDataUpdated, etag) }
                     } else {
-                        return Single<(response: T?, isServerDataUpdated: Bool, etag: String)>.just((nil, false, ""))
+                        return Single<(response: T?, isServerDataUpdated: Bool, etag: String)>.just((nil, false, etag))
                     }
                     
                 case .failure(let networkError):

--- a/FIFAGG/FIFAGG/Infrastructure/Network/EndPoint.swift
+++ b/FIFAGG/FIFAGG/Infrastructure/Network/EndPoint.swift
@@ -118,6 +118,7 @@ extension Requestable {
         }
         urlRequest.httpMethod = method.rawValue
         urlRequest.allHTTPHeaderFields = allHeaders
+        urlRequest.cachePolicy = .reloadIgnoringCacheData
         return urlRequest
     }
     


### PR DESCRIPTION
## 📌 이슈

close #22 

## 내용
- HTTP 통신 캐싱 하지 않도록 설정
  - HTTP 통신 캐싱으로 인해, 이전 Request에 대한 Response캐쉬값이 Response되어 실제 서버에 접근되지 않았음, 그로인해 실제 서버 API Etag에 대한 StatusCode(304)가 Response되지 않았음
- division 메타데이터에 대한 UserDefaults 키값 오타 수정(SPPosition 키값으로 되어 있었음)
- Status 304일때, 즉 해당 서버 API가 업데이트 되지 않을때도, 받아온 etag 저장하도록 수정
  - 해당 경우 공백문자를 지정하고 있었음, 그러면 etag말고 공백문자가 UserDefaults에 저장돼 다음 통신 때, 무조건 statusCode 200으로 데이터 가져옴